### PR TITLE
Added UUID Utils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.0] - 2020-09-14
+### Added
+* UuidUtils was added. It is expected to be used to generate all UUIDs used in Transferwise.

--- a/build.gradle
+++ b/build.gradle
@@ -33,4 +33,9 @@ dependencies {
     testImplementation 'org.codehaus.groovy:groovy:2.5.8'
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation 'org.awaitility:awaitility:4.0.2'
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.8
+version=1.3.0

--- a/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -19,7 +19,9 @@ public class UuidUtils {
   }
 
   /**
-   * Uses 38 bit prefix based on current milliseconds giving 3181 days roll-over.
+   * Random UUID with 38 bit prefix based on current milliseconds from epoch.
+   * 
+   * <p>Giving about 3181 days roll-over.
    */
   public static UUID generatePrefixCombUuid() {
     return generatePrefixCombUuid(38);
@@ -27,8 +29,12 @@ public class UuidUtils {
 
   /**
    * Generates time prefixed random UUID.
+   * 
+   * <p>Time will be truncated so that only given amount of bits will remain. 
+   * 
+   * <p>Rest of the bits in UUID are completely random.
    *
-   * @param timePrefixLengthBits how much information to retain from the time. Technically time is left shifted so many bits.
+   * @param timePrefixLengthBits technically we left-shift the current time-millis by that amount.
    */
   public static UUID generatePrefixCombUuid(int timePrefixLengthBits) {
     if (timePrefixLengthBits < 1 || timePrefixLengthBits > 63) {

--- a/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -1,0 +1,75 @@
+package com.transferwise.common.baseutils;
+
+import com.transferwise.common.baseutils.clock.ClockHolder;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.SecureRandom;
+import java.util.UUID;
+
+public class UuidUtils {
+
+  private static final SecureRandom numberGenerator = new SecureRandom();
+
+  private static long[] BIT_MASK = new long[64];
+
+  static {
+    for (int i = 0; i < 64; i++) {
+      BIT_MASK[i] = (1L << i) - 1;
+    }
+  }
+
+  /**
+   * Uses 38 bit prefix based on current milliseconds giving 3181 days roll-over.
+   */
+  public static UUID generatePrefixCombUuid() {
+    return generatePrefixCombUuid(38);
+  }
+
+  /**
+   * Generates time prefixed random UUID.
+   *
+   * @param timePrefixLengthBits how much information to retain from the time. Technically time is left shifted so many bits.
+   */
+  public static UUID generatePrefixCombUuid(int timePrefixLengthBits) {
+    if (timePrefixLengthBits < 1 || timePrefixLengthBits > 63) {
+      throw new IllegalArgumentException("Prefix length " + timePrefixLengthBits + " has to be between 1 and 63, inclusively.");
+    }
+
+    long timestamp = ClockHolder.getClock().millis();
+
+    long msb = (timestamp << (64 - timePrefixLengthBits)) | (numberGenerator.nextLong() & BIT_MASK[64 - timePrefixLengthBits]);
+    long lsb = numberGenerator.nextLong();
+    return new UUID(msb, lsb);
+  }
+
+  public static UUID toUuid(byte[] bytes) {
+    if (bytes == null) {
+      throw new IllegalArgumentException("bytes must not be null.");
+    } else if (bytes.length != 16) {
+      throw new IllegalArgumentException("bytes has to contain exactly 16 bytes.");
+    }
+
+    long msb = 0;
+    long lsb = 0;
+    for (int i = 0; i < 8; i++) {
+      msb = (msb << 8) | (bytes[i] & 0xff);
+    }
+    for (int i = 8; i < 16; i++) {
+      lsb = (lsb << 8) | (bytes[i] & 0xff);
+    }
+    long mostSigBits = msb;
+    long leastSigBits = lsb;
+
+    return new UUID(mostSigBits, leastSigBits);
+  }
+
+  public static byte[] toBytes(UUID uuid) {
+    byte[] bytes = new byte[16];
+    ByteBuffer bb = ByteBuffer.wrap(bytes);
+    bb.order(ByteOrder.BIG_ENDIAN);
+    bb.putLong(uuid.getMostSignificantBits());
+    bb.putLong(uuid.getLeastSignificantBits());
+
+    return bytes;
+  }
+}

--- a/src/main/java/com/transferwise/common/baseutils/tracing/IWithXRequestId.java
+++ b/src/main/java/com/transferwise/common/baseutils/tracing/IWithXRequestId.java
@@ -1,5 +1,11 @@
 package com.transferwise.common.baseutils.tracing;
 
+/**
+ * Old Tw tracking system.
+ * 
+ * @deprecated in favor of Jaegar tracing.
+ */
+@Deprecated
 public interface IWithXRequestId {
 
   void setXRequestId(String xRequestId);

--- a/src/main/java/com/transferwise/common/baseutils/tracing/IXRequestIdHolder.java
+++ b/src/main/java/com/transferwise/common/baseutils/tracing/IXRequestIdHolder.java
@@ -5,6 +5,12 @@ import static java.lang.Character.isLetterOrDigit;
 import com.transferwise.common.baseutils.function.RunnableWithException;
 import java.util.concurrent.Callable;
 
+/**
+ * Old Tw tracking system.
+ * 
+ * @deprecated in favor of Jaegar tracing.
+ */
+@Deprecated
 public interface IXRequestIdHolder {
 
   int MAX_REQUEST_ID_LENGTH = 36;

--- a/src/main/java/com/transferwise/common/baseutils/tracing/MdcXRequestIdHolder.java
+++ b/src/main/java/com/transferwise/common/baseutils/tracing/MdcXRequestIdHolder.java
@@ -8,6 +8,11 @@ import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 
+/**
+ * Old Tw tracking system.
+ *
+ * @deprecated in favor of Jaegar tracing.
+ */
 public class MdcXRequestIdHolder implements IXRequestIdHolder {
 
   @Setter

--- a/src/test/groovy/com/transferwise/common/baseutils/BaseTest.java
+++ b/src/test/groovy/com/transferwise/common/baseutils/BaseTest.java
@@ -1,0 +1,12 @@
+package com.transferwise.common.baseutils;
+
+import com.transferwise.common.baseutils.clock.TestClock;
+import org.junit.jupiter.api.AfterEach;
+
+public class BaseTest {
+
+  @AfterEach
+  public void baseTestTearDown() {
+    TestClock.reset();
+  }
+}

--- a/src/test/groovy/com/transferwise/common/baseutils/ExceptionUtilsTest.java
+++ b/src/test/groovy/com/transferwise/common/baseutils/ExceptionUtilsTest.java
@@ -8,9 +8,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.Callable;
 import lombok.SneakyThrows;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ExceptionUtilsTest {
+public class ExceptionUtilsTest extends BaseTest {
 
   @Test
   public void testUncheckedCall() {

--- a/src/test/groovy/com/transferwise/common/baseutils/UuidUtilsTest.java
+++ b/src/test/groovy/com/transferwise/common/baseutils/UuidUtilsTest.java
@@ -1,0 +1,62 @@
+package com.transferwise.common.baseutils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.transferwise.common.baseutils.clock.TestClock;
+import java.time.Duration;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomUtils;
+import org.assertj.core.util.Sets;
+import org.junit.jupiter.api.Test;
+
+public class UuidUtilsTest extends BaseTest {
+
+  @Test
+  public void defaultPrefixCombUuidIsGrowingOverTime() {
+    TestClock clock = TestClock.createAndRegister();
+
+    int n = 100;
+
+    UUID[] uuids = new UUID[n];
+    for (int i = 0; i < n; i++) {
+      uuids[i] = UuidUtils.generatePrefixCombUuid();
+      clock.tick(Duration.ofMillis(2));
+    }
+
+    long previousTime = -1;
+    for (int i = 0; i < n; i++) {
+      long time = uuids[i].getMostSignificantBits() >>> (64 - 38);
+
+      if (previousTime != -1) {
+        assertThat(previousTime).isLessThan(time);
+      }
+      previousTime = time;
+    }
+
+    assertThat(uuids).isSorted();
+    assertThat(Sets.newTreeSet(uuids).size()).isEqualTo(n);
+  }
+
+  @Test
+  public void convertingFromUuidAndBackToBytesEndWithTheSameResult() {
+    UUID expected = UUID.randomUUID();
+
+    byte[] bytes = UuidUtils.toBytes(expected);
+    UUID result = UuidUtils.toUuid(bytes);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void convertingFromBytesAndBackToUuidEndWithTheSameResult() {
+    byte[] expected = RandomUtils.nextBytes(16);
+
+    UUID uuid = UuidUtils.toUuid(expected);
+    byte[] result = UuidUtils.toBytes(uuid);
+
+    assertArrayEquals(expected, result);
+  }
+
+}

--- a/src/test/groovy/com/transferwise/common/baseutils/concurrency/SimpleScheduledTaskExecutorTest.java
+++ b/src/test/groovy/com/transferwise/common/baseutils/concurrency/SimpleScheduledTaskExecutorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.transferwise.common.baseutils.BaseTest;
 import com.transferwise.common.baseutils.clock.TestClock;
 import java.time.Duration;
 import java.util.Map;
@@ -14,15 +15,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @Slf4j
 @SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:MultipleStringLiterals"})
-public class SimpleScheduledTaskExecutorTest {
+public class SimpleScheduledTaskExecutorTest extends BaseTest {
 
   @Test
-  @Ignore("This test is for manual tweaking.")
+  @Disabled("This test is for manual tweaking.")
   public void testManually() throws InterruptedException {
     ExecutorService executorService = Executors.newCachedThreadPool();
     SimpleScheduledTaskExecutor scheduledTaskExecutor = new SimpleScheduledTaskExecutor("test", executorService);
@@ -43,7 +44,7 @@ public class SimpleScheduledTaskExecutorTest {
   }
 
   @Test
-  @Ignore("This test is for manual tweaking.")
+  @Disabled("This test is for manual tweaking.")
   public void testManuallyOnceExecution() throws InterruptedException {
     ExecutorService executorService = Executors.newCachedThreadPool();
     SimpleScheduledTaskExecutor scheduledTaskExecutor = new SimpleScheduledTaskExecutor("test", executorService);

--- a/src/test/groovy/com/transferwise/common/baseutils/tracing/MdcXRequestIdHolderTest.java
+++ b/src/test/groovy/com/transferwise/common/baseutils/tracing/MdcXRequestIdHolderTest.java
@@ -2,9 +2,11 @@ package com.transferwise.common.baseutils.tracing;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import com.transferwise.common.baseutils.BaseTest;
+import org.junit.jupiter.api.Test;
 
-public class MdcXRequestIdHolderTest {
+
+public class MdcXRequestIdHolderTest extends BaseTest {
 
   private final MdcXRequestIdHolder mdcXRequestIdHolder = new MdcXRequestIdHolder();
 


### PR DESCRIPTION
## Context

We need sequential UUIDs for more efficient storage in databases.

### Changes

38 bit time prefixed UUID will be the preferred way of generating UUIDs for optimal storage performance.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
