### PR TITLE
`generateSecureUuid` was added to `UuidUtils`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2020-09-17
+### Added
+* `generateSecureUuid` was added to `UuidUtils`.
+
 ## [1.3.0] - 2020-09-14
 ### Added
 * UuidUtils was added. It is expected to be used to generate all UUIDs used in Transferwise.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.0
+version=1.3.1

--- a/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -19,9 +19,18 @@ public class UuidUtils {
   }
 
   /**
+   * Completely random UUID suitable for authentication tokens.
+   */
+  public static UUID generateSecureUuid() {
+    return new UUID(numberGenerator.nextLong(), numberGenerator.nextLong());
+  }
+  
+  /**
    * Random UUID with 38 bit prefix based on current milliseconds from epoch.
    * 
    * <p>Giving about 3181 days roll-over.
+   * 
+   * <p>This UUID is not suitable for things like session and authentication tokens.
    */
   public static UUID generatePrefixCombUuid() {
     return generatePrefixCombUuid(38);
@@ -33,6 +42,8 @@ public class UuidUtils {
    * <p>Time will be truncated so that only given amount of bits will remain. 
    * 
    * <p>Rest of the bits in UUID are completely random.
+   * 
+   * <p>This UUID is not suitable for things like session and authentication tokens.
    *
    * @param timePrefixLengthBits technically we left-shift the current time-millis by that amount.
    */

--- a/src/test/groovy/com/transferwise/common/baseutils/UuidUtilsTest.java
+++ b/src/test/groovy/com/transferwise/common/baseutils/UuidUtilsTest.java
@@ -59,4 +59,9 @@ public class UuidUtilsTest extends BaseTest {
     assertArrayEquals(expected, result);
   }
 
+  @Test
+  public void generatingSecuredUuidWorks() {
+    assertThat(UuidUtils.generateSecureUuid()).isNotNull();
+  }
+
 }


### PR DESCRIPTION
## Context

We need to make it less probably for someone using prefix combed uuids for authentication tokens.

### Changes

`generateSecureUuid` was added to `UuidUtils`.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
