### PR TITLE
Added ConnectionProxy interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.0] - 2021-05-27
-### Changed
-* Moved from JDK 8 to JDK 11.
-* Starting to push to Maven Central again.
-
 ## [1.6.0] - 2021-06-11
 ### Changed
 * Added ConnectionProxy interface
 
-## [1.5.0] - 2021-06-06
+## [1.5.0] - 2021-05-27
 ### Changed
-* JDK 11+ is now requirement
+* Moved from JDK 8 to JDK 11.
+* Starting to push to Maven Central again.
 
 ## [1.4.1] - 2021-03-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved from JDK 8 to JDK 11.
 * Starting to push to Maven Central again.
 
+## [1.6.0] - 2021-06-11
+### Changed
+* Added ConnectionProxy interface
+
+## [1.5.0] - 2021-06-06
+### Changed
+* JDK 11+ is now requirement
+
 ## [1.4.1] - 2021-03-14
 ### Changed
 * Allowing clearing only specific metrics from meter cache.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.5.0
+version=1.6.0

--- a/src/main/java/com/transferwise/common/baseutils/jdbc/ConnectionProxy.java
+++ b/src/main/java/com/transferwise/common/baseutils/jdbc/ConnectionProxy.java
@@ -1,0 +1,8 @@
+package com.transferwise.common.baseutils.jdbc;
+
+import java.sql.Connection;
+
+public interface ConnectionProxy extends Connection {
+
+  Connection getTargetConnection();
+}


### PR DESCRIPTION
## Context

We need to unwrap HikariDataSource in tw-reliable-jdbc from SpyqlConnection.

For that it would be nice to have an interface we can use for it.

### Changes

Added ConnectionProxy interface.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
