### PR TITLE
Add TestClock#plus(String) method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 references:
   container_config: &container_config
     docker:
-      - image: docker.tw.ee/circle_openjdk13:latest
+      - image: docker.tw.ee/circle_openjdk11:latest
         user: circleci
         environment:
           TERM: vt100

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 references:
   container_config: &container_config
     docker:
-      - image: arti.tw.ee/circle_openjdk11:latest
+      - image: docker.tw.ee/circle_openjdk13:latest
         user: circleci
         environment:
           TERM: vt100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2021-11-04
+### Changed
+* Added TestClock#plus(String) method.
+
+
 ## [1.6.0] - 2021-06-11
 ### Changed
 * Added ConnectionProxy interface

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.6.0
+version=1.7.0

--- a/src/main/java/com/transferwise/common/baseutils/clock/TestClock.java
+++ b/src/main/java/com/transferwise/common/baseutils/clock/TestClock.java
@@ -65,6 +65,7 @@ public class TestClock extends Clock {
   }
 
   /**
+   * Advances current test clock by duration represented by string.
    * @see java.time.Duration#parse(CharSequence)
    * @param duration a string representing a Duration, for example "P1D" for 1 day or "PT1M" for 1 minute
    */

--- a/src/main/java/com/transferwise/common/baseutils/clock/TestClock.java
+++ b/src/main/java/com/transferwise/common/baseutils/clock/TestClock.java
@@ -63,4 +63,12 @@ public class TestClock extends Clock {
   public void tick(Duration duration) {
     instant = instant.plus(duration);
   }
+
+  /**
+   * @see java.time.Duration#parse(CharSequence)
+   * @param duration a string representing a Duration, for example "P1D" for 1 day or "PT1M" for 1 minute
+   */
+  public void plus(String duration) {
+    tick(Duration.parse(duration));
+  }
 }

--- a/src/test/groovy/com/transferwise/common/baseutils/clock/TestClockSpec.groovy
+++ b/src/test/groovy/com/transferwise/common/baseutils/clock/TestClockSpec.groovy
@@ -1,0 +1,18 @@
+package com.transferwise.common.baseutils.clock
+
+import spock.lang.Specification
+
+import java.time.Instant
+
+class TestClockSpec extends Specification {
+    def "plus can be used from groovy"() {
+        given:
+        def clock = new TestClock(Instant.parse('2021-11-04T00:00:00Z'))
+
+        when:
+        clock + 'P1D'
+
+        then:
+        clock.instant().toString() == '2021-11-05T00:00:00Z'
+    }
+}


### PR DESCRIPTION
## Context
Groovy supports [operator overloading](https://groovy-lang.org/dsls.html#_operator_overloading). 
If a class `TestClock` has a method named `plus` with one parameter `plus(String)` then it can be used in groovy code by writing `clock + '...'`.

In spock tests instead of writing
```groovy
clock.tick(Duration.ofDays(1))
```
we'll be able to write
```groovy
clock + 'P1D'
```
and the clock will tick 1 day.


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
