### PR TITLE
Add junit class ordering via annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2021-11-25
+### Added
+* `AnnotationClassOrderer` - JUnit 5 custom orderer, to run test classes in order defined by an annotation
+* `ClassOrder` - Annotation for custom ordering of test classes
+
 ## [1.7.0] - 2021-11-04
 ### Changed
 * Added TestClock#plus(String) method.

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     implementation 'org.apache.commons:commons-lang3'
 
+    implementation(platform('org.junit:junit-bom:5.8.1'))
+    implementation('org.junit.jupiter:junit-jupiter')
+
     testImplementation 'junit:junit'
     testImplementation 'org.codehaus.groovy:groovy:2.5.14'
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.7.0
+version=1.8.0

--- a/src/main/java/com/transferwise/common/baseutils/test/AnnotationClassOrderer.java
+++ b/src/main/java/com/transferwise/common/baseutils/test/AnnotationClassOrderer.java
@@ -5,6 +5,11 @@ import org.junit.jupiter.api.ClassDescriptor;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.ClassOrdererContext;
 
+/**
+ * Usage in junit-platform.properties: ```junit.jupiter.testclass.order.default=org.example.tests.AnnotationClassOrderer```
+ * <p>
+ * Used in conjunction with {@linkplain ClassOrder} annotations to explicitly define test ordering in JUnit 5.8+
+ */
 public class AnnotationClassOrderer implements ClassOrderer {
 
   @Override

--- a/src/main/java/com/transferwise/common/baseutils/test/AnnotationClassOrderer.java
+++ b/src/main/java/com/transferwise/common/baseutils/test/AnnotationClassOrderer.java
@@ -1,0 +1,26 @@
+package com.transferwise.common.baseutils.test;
+
+import java.util.Comparator;
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+
+public class AnnotationClassOrderer implements ClassOrderer {
+
+  @Override
+  public void orderClasses(ClassOrdererContext context) {
+    context.getClassDescriptors().sort((Comparator<ClassDescriptor>) (d1, d2) -> {
+      ClassOrder a1 = d1.getTestClass().getDeclaredAnnotation(ClassOrder.class);
+      ClassOrder a2 = d2.getTestClass().getDeclaredAnnotation(ClassOrder.class);
+      if (a1 == null) {
+        return 1;
+      }
+
+      if (a2 == null) {
+        return -1;
+      }
+
+      return Integer.compare(a1.value(), a2.value());
+    });
+  }
+}

--- a/src/main/java/com/transferwise/common/baseutils/test/ClassOrder.java
+++ b/src/main/java/com/transferwise/common/baseutils/test/ClassOrder.java
@@ -5,6 +5,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Used by {@linkplain AnnotationClassOrderer} to determine order
+ * of execution of JUnit 5.8+ test classes.
+ *
+ * <pre>{@code
+ * @ClassOrder(1)
+ * class MyTestClass {
+ *
+ * }</pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ClassOrder {

--- a/src/main/java/com/transferwise/common/baseutils/test/ClassOrder.java
+++ b/src/main/java/com/transferwise/common/baseutils/test/ClassOrder.java
@@ -1,0 +1,12 @@
+package com.transferwise.common.baseutils.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ClassOrder {
+  int value() default Integer.MAX_VALUE;
+}

--- a/src/test/java/com/transferwise/common/baseutils/concurrency/SimpleScheduledTaskExecutorTest.java
+++ b/src/test/java/com/transferwise/common/baseutils/concurrency/SimpleScheduledTaskExecutorTest.java
@@ -10,7 +10,6 @@ import com.transferwise.common.baseutils.BaseTest;
 import com.transferwise.common.baseutils.clock.TestClock;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/transferwise/common/baseutils/test/AnnotationClassOrdererTest.java
+++ b/src/test/java/com/transferwise/common/baseutils/test/AnnotationClassOrdererTest.java
@@ -20,27 +20,27 @@ class AnnotationClassOrdererTest {
   @RequiredArgsConstructor
   static class MockClassDescriptor implements ClassDescriptor {
 
-    private final Class<?> aClass;
+    private final Class<?> theClass;
 
     @Override
     public Class<?> getTestClass() {
-      return aClass;
+      return theClass;
     }
 
     @Override
     public String getDisplayName() {
-      return aClass.getName();
+      return theClass.getName();
     }
 
     @Override
     public boolean isAnnotated(Class<? extends Annotation> annotationType) {
-      return aClass.getAnnotations().length > 0;
+      return theClass.getAnnotations().length > 0;
     }
 
     @Override
     public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
       try {
-        return Optional.of(aClass.getAnnotation(annotationType));
+        return Optional.of(theClass.getAnnotation(annotationType));
       } catch (Exception e) {
         return Optional.empty();
       }
@@ -88,8 +88,8 @@ class AnnotationClassOrdererTest {
       @Override
       public List<? extends ClassDescriptor> getClassDescriptors() {
         if (values.isEmpty()) {
-          for (Class<?> aClass : classes) {
-            values.add(new MockClassDescriptor(aClass));
+          for (Class<?> theClass : classes) {
+            values.add(new MockClassDescriptor(theClass));
           }
         }
 

--- a/src/test/java/com/transferwise/common/baseutils/test/AnnotationClassOrdererTest.java
+++ b/src/test/java/com/transferwise/common/baseutils/test/AnnotationClassOrdererTest.java
@@ -1,0 +1,96 @@
+package com.transferwise.common.baseutils.test;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrdererContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnnotationClassOrdererTest {
+
+  @ClassOrder(2)
+  static class TestA {
+
+  }
+
+  @ClassOrder(3)
+  static class TestB {
+
+  }
+
+  @ClassOrder(1)
+  static class TestC {
+
+  }
+
+  @RequiredArgsConstructor
+  static class MockClassDescriptor implements ClassDescriptor {
+
+    private final Class<?> aClass;
+
+    @Override
+    public Class<?> getTestClass() {
+      return aClass;
+    }
+
+    @Override
+    public String getDisplayName() {
+      return aClass.getName();
+    }
+
+    @Override
+    public boolean isAnnotated(Class<? extends Annotation> annotationType) {
+      return aClass.getAnnotations().length > 0;
+    }
+
+    @Override
+    public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+      try {
+        return Optional.of(aClass.getAnnotation(annotationType));
+      } catch (Exception e) {
+        return Optional.empty();
+      }
+    }
+
+    @Override
+    public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+      return List.of();
+    }
+  }
+
+  private final AnnotationClassOrderer orderer = new AnnotationClassOrderer();
+
+  @Test
+  void test() {
+    ClassOrdererContext context = new ClassOrdererContext() {
+      private final List<MockClassDescriptor> values = new ArrayList<>();
+
+      @Override
+      public List<? extends ClassDescriptor> getClassDescriptors() {
+        if (values.isEmpty()) {
+          values.add(new MockClassDescriptor(TestA.class));
+          values.add(new MockClassDescriptor(TestB.class));
+          values.add(new MockClassDescriptor(TestC.class));
+        }
+
+        return values;
+      }
+
+      @Override
+      public Optional<String> getConfigurationParameter(String key) {
+        return Optional.empty();
+      }
+    };
+
+    orderer.orderClasses(context);
+    assertThat(context.getClassDescriptors()).hasSize(3);
+    assertThat(context.getClassDescriptors().get(0).getTestClass()).isEqualTo(TestC.class);
+    assertThat(context.getClassDescriptors().get(1).getTestClass()).isEqualTo(TestA.class);
+    assertThat(context.getClassDescriptors().get(2).getTestClass()).isEqualTo(TestB.class);
+  }
+}


### PR DESCRIPTION
## Context

Added a simple `ClassOrderer` for JUnit 5, that allows consumers to specify the order in which their test classes are run.

Done with an annotation on the test class like so:
```
@ClassOrder(1)
class MySickTestClass {
}
```

Classes with the annotation present will take precedent over un-annotated classes.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
