### PR TITLE
Log error if rollback fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2022-09-12
+### Changed
+* If the Callable supplied to TransactionHelper#call throws an exception, there is an attempt to rollback. Thus far, if the rollback also threw an
+exception, it got thrown and the exception from Callable was lost. Starting in this version, any exception from the rollback is caught and logged,
+and the exception from Callable gets thrown.
+
 ## [1.7.1] - 2021-12-08
 ### Changed
 * Build and Publish using GitHub Actions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.7.1
+version=1.8.0

--- a/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsHelper.java
+++ b/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsHelper.java
@@ -1,6 +1,7 @@
 package com.transferwise.common.baseutils.transactionsmanagement;
 
 import com.transferwise.common.baseutils.ExceptionUtils;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,7 +114,7 @@ public class TransactionsHelper implements ITransactionsHelper {
           try {
             transactionManager.rollback(status);
           } catch (Throwable t2) {
-            log.error(t2.getMessage(), t2);
+            log.error("Failed to rollback transaction '{}' ({}).", name != null ? name : "<no-txn-name>", def, t2);
           }
           throw t;
         }

--- a/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsHelper.java
+++ b/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsHelper.java
@@ -2,6 +2,7 @@ package com.transferwise.common.baseutils.transactionsmanagement;
 
 import com.transferwise.common.baseutils.ExceptionUtils;
 import java.util.concurrent.Callable;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -9,6 +10,7 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
+@Slf4j
 public class TransactionsHelper implements ITransactionsHelper {
 
   @Autowired
@@ -108,7 +110,11 @@ public class TransactionsHelper implements ITransactionsHelper {
         try {
           result = callable.call();
         } catch (Throwable t) {
-          transactionManager.rollback(status);
+          try {
+            transactionManager.rollback(status);
+          } catch (Throwable t2) {
+            log.error(t2.getMessage(), t2);
+          }
           throw t;
         }
         transactionManager.commit(status);


### PR DESCRIPTION
## Context

Current behavior makes certain scenarios difficult to troubleshoot.

From changelog:
>If the Callable supplied to TransactionHelper#call throws an exception, there is an attempt to rollback. Thus far, if the rollback also threw an exception, it got thrown and the exception from Callable was lost. Starting in this version, any exception from the rollback is caught and logged, and the exception from Callable gets thrown.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
