### PR TITLE
Small fix for wrapping thread naming for execute method as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,50 +1,76 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2022-11-02
+
+### Fixed
+
+* `ThreadNamingExecutorServiceWrapper` is now setting thread name for `execute` method calls as well.
+
 ## [1.8.0] - 2022-09-12
+
 ### Changed
+
 * If the Callable supplied to TransactionHelper#call throws an exception, there is an attempt to rollback. Thus far, if the rollback also threw an
-exception, it got thrown and the exception from Callable was lost. Starting in this version, any exception from the rollback is caught and logged,
-and the exception from Callable gets thrown.
+  exception, it got thrown and the exception from Callable was lost. Starting in this version, any exception from the rollback is caught and logged,
+  and the exception from Callable gets thrown.
 
 ## [1.7.1] - 2021-12-08
+
 ### Changed
+
 * Build and Publish using GitHub Actions
 
 ## [1.7.0] - 2021-11-04
+
 ### Changed
+
 * Added TestClock#plus(String) method.
 
-
 ## [1.6.0] - 2021-06-11
+
 ### Changed
+
 * Added ConnectionProxy interface
 
 ## [1.5.0] - 2021-05-27
+
 ### Changed
+
 * Moved from JDK 8 to JDK 11.
 * Starting to push to Maven Central again.
 
 ## [1.4.1] - 2021-03-14
+
 ### Changed
+
 * Allowing clearing only specific metrics from meter cache.
 * Minor optimization in transactions helper.
 
 ## [1.4.0] - 2021-03-01
+
 ### Added
+
 * MeterCache to avoid Micrometer's MeterRegistry's inefficiencies.
 
 ## [1.3.2] - 2020-09-18
+
 ### Changed
+
 * Our UUIDs have version 4 identifier now.
 
 ## [1.3.1] - 2020-09-17
+
 ### Added
+
 * `generateSecureUuid` was added to `UuidUtils`.
 
 ## [1.3.0] - 2020-09-14
+
 ### Added
+
 * UuidUtils was added. It is expected to be used to generate all UUIDs used in Transferwise.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*              @transferwise/central-sre
+*              @transferwise/application-engineering

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -31,11 +31,33 @@ repositories {
     mavenLocal()
 }
 
+configurations {
+    local {
+        canBeResolved(false)
+        canBeConsumed(false)
+    }
+    compileClasspath {
+        extendsFrom(local)
+    }
+    runtimeClasspath {
+        extendsFrom(local)
+    }
+    testCompileClasspath {
+        extendsFrom(local)
+    }
+    testRuntimeClasspath {
+        extendsFrom(local)
+    }
+    annotationProcessor {
+        extendsFrom(local)
+    }
+    testAnnotationProcessor {
+        extendsFrom(local)
+    }
+}
+
 dependencies {
-    annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
-    compileOnly(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
-    implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
-    testAnnotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
+    local(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
 
     annotationProcessor("org.projectlombok:lombok")
 
@@ -85,6 +107,19 @@ publishing {
             from components.java
             afterEvaluate {
                 artifactId = projectArtifactName
+            }
+
+            /*
+             This ensures that libraries will have explicit dependency versions in their Maven POM and Gradle module files, so that there would be less
+             ambiguity and less chances of dependency conflicts.
+            */
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionOf('runtimeClasspath')
+                }
             }
 
             pom {
@@ -150,6 +185,8 @@ test {
 
 tasks.findAll { it.name.startsWith("spotbugs") }*.configure {
     effort = "max"
+
+    excludeFilter = file('spotbugs-exclude.xml')
 
     reports {
         xml.required = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 import org.eclipse.jgit.api.errors.RefAlreadyExistsException
 
 plugins {
-    id "com.github.spotbugs" version "4.7.0"
+    id "com.github.spotbugs" version "5.0.13"
     id "idea"
-    id 'org.ajoberstar.grgit' version '4.1.1'
+    id 'org.ajoberstar.grgit' version '5.0.0'
     id 'io.github.gradle-nexus.publish-plugin' version "1.1.0"
 }
 
@@ -22,19 +22,19 @@ apply from: 'build.common.gradle'
 dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework:spring-tx'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.5.2'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
     compileOnly 'io.micrometer:micrometer-core'
 
     implementation 'org.slf4j:slf4j-api'
     implementation 'org.apache.commons:commons-lang3'
 
     testImplementation 'junit:junit'
-    testImplementation 'org.spockframework:spock-core:2.0-groovy-3.0'
-    testImplementation 'org.awaitility:awaitility:4.1.1'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'io.micrometer:micrometer-core'
     testImplementation 'org.assertj:assertj-core'
 
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    //testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,6 @@ dependencies {
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'io.micrometer:micrometer-core'
     testImplementation 'org.assertj:assertj-core'
-
-    //testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }
 
 test {

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -241,7 +241,6 @@
               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.8.0
+version=1.8.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <Match>
+    <Bug code="EI,EI2,MS"/>
+  </Match>
+</FindBugsFilter>

--- a/src/main/java/com/transferwise/common/baseutils/concurrency/ThreadNamingExecutorServiceWrapper.java
+++ b/src/main/java/com/transferwise/common/baseutils/concurrency/ThreadNamingExecutorServiceWrapper.java
@@ -85,10 +85,10 @@ public class ThreadNamingExecutorServiceWrapper implements ExecutorService {
 
   @Override
   public void execute(Runnable command) {
-    delegate.execute(command);
+    delegate.execute(wrap(command));
   }
 
-  private <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks) {
+  protected <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks) {
     return tasks.stream().map(this::wrap).collect(Collectors.toList());
   }
 


### PR DESCRIPTION
## Context

Small fix for wrapping thread naming for execute method as well.

execute() can have less latency in certain implementation, but was not wrapped properly.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
