### PR TITLE
use constructor injection on transactions helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2023-06-06
+
+### Changed (Breaking)
+
+* `TransactionsHelper` now has constructor injection for `PlatformTransactionManager`
+
 ## [1.10.1] - 2023-05-08
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.10.1
+version=2.0.0

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsConfiguration.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsConfiguration.java
@@ -2,12 +2,13 @@ package com.transferwise.common.baseutils.transactionsmanagement;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.PlatformTransactionManager;
 
 public class TransactionsConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(ITransactionsHelper.class)
-  public TransactionsHelper twTransactionsHelper() {
-    return new TransactionsHelper();
+  public TransactionsHelper twTransactionsHelper(PlatformTransactionManager platformTransactionManager) {
+    return new TransactionsHelper(platformTransactionManager);
   }
 }

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsHelper.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/transactionsmanagement/TransactionsHelper.java
@@ -3,7 +3,6 @@ package com.transferwise.common.baseutils.transactionsmanagement;
 import com.transferwise.common.baseutils.ExceptionUtils;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Isolation;
@@ -12,9 +11,11 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 @Slf4j
 public class TransactionsHelper implements ITransactionsHelper {
+  private final PlatformTransactionManager transactionManager;
 
-  @Autowired
-  private PlatformTransactionManager transactionManager;
+  public TransactionsHelper(PlatformTransactionManager transactionManager) {
+    this.transactionManager = transactionManager;
+  }
 
   @Override
   public boolean isRollbackOnly() {


### PR DESCRIPTION
## Context
Sometimes it's necessary to configure which `PlatformTransactionManager` will be used with the helper. For example, we have cases where the MongoDB one is needed over the SQL. The PR allows it to happen.

I tagged this as a breaking change because lots of services wire their own `ITransactionsHelper`, and it uses the default constructor.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
