### PR TITLE
Port JavaTimeModuleFactory from old common lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.3] - 2023-08-08
+
+### Added
+
+* Ported `JavaTimeModuleFactory` from old common lib so that the lib can be removed in the future. It provides consistent millisecond serialisation of `Instant` and `ZonedDateTime` objects.
+
 ## [1.10.2] - 2023-07-28
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -20,6 +20,8 @@ ext {
             spotbugsAnnotations   : "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}",
             springBootStarter     : "org.springframework.boot:spring-boot-starter",
             springTx              : "org.springframework:spring-tx",
+            jacksonDatabind       : "com.fasterxml.jackson.core:jackson-databind",
+            jacksonJsr310         : "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.10.2
+version=1.10.3

--- a/tw-base-utils/build.gradle
+++ b/tw-base-utils/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 
     implementation libraries.commonsLang3
     implementation libraries.slf4jApi
+    implementation libraries.jacksonDatabind
+    implementation libraries.jacksonJsr310
 
     testImplementation libraries.awaitility
     testImplementation libraries.guava

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/JavaTimeModuleFactory.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/JavaTimeModuleFactory.java
@@ -1,0 +1,48 @@
+package com.transferwise.common.baseutils.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+/**
+ * Solves undesired behaviour of default formatter that will skip milliseconds in the string at exact seconds, i.e. `2012-06-30T12:30:40Z` is
+ * searalised as `2012-06-30T12:30:40.000Z`. Starting from Java 9 timestamps have microseconds, and starting from Java 15 timestamps have nanoseconds
+ * (dependent on OS). This module allows serialising all timestamps with consistent millisecond precision.
+ */
+public final class JavaTimeModuleFactory {
+
+  public static JavaTimeModule consistentMillisecondsTimeModule() {
+    JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+    DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
+
+    ZonedDateTimeSerializer dateTimeSerializer = new ZonedDateTimeSerializer(formatter);
+    javaTimeModule.addSerializer(ZonedDateTime.class, dateTimeSerializer);
+
+    javaTimeModule.addSerializer(Instant.class, new InstantSerializer(formatter));
+
+    return javaTimeModule;
+  }
+
+  public static class InstantSerializer extends JsonSerializer<Instant> {
+
+    private final DateTimeFormatter dateFormatter;
+
+    public InstantSerializer(DateTimeFormatter dateFormatter) {
+      this.dateFormatter = dateFormatter;
+    }
+
+    @Override
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+      String str = dateFormatter.format(value);
+      gen.writeString(str);
+    }
+  }
+}

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/jackson/JavaTimeModuleFactoryTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/jackson/JavaTimeModuleFactoryTest.java
@@ -1,0 +1,64 @@
+package com.transferwise.common.baseutils.jackson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JavaTimeModuleFactoryTest {
+
+  static ObjectMapper oldObjectMapper;
+  static ObjectMapper objectMapper;
+
+  @BeforeAll
+  public static void setup() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(JavaTimeModuleFactory.consistentMillisecondsTimeModule());
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    oldObjectMapper = new ObjectMapper();
+    oldObjectMapper.registerModule(new JavaTimeModule());
+  }
+
+  @Test
+  public void testTimestampBackwardCompatibleReading() throws Exception {
+    Instant sourceTimestamp = Instant.now();
+    String jsonString = oldObjectMapper.writeValueAsString(sourceTimestamp);
+    Instant targetTimestamp = objectMapper.readValue(jsonString, Instant.class);
+    assertEquals(sourceTimestamp, targetTimestamp);
+  }
+
+  @Test
+  public void testTimestampBackwardCompatibleWriting() throws Exception {
+    // Depending on java version Instant.now may produce micro or nanoseconds, but that's not the point of the test, therefore truncating
+    Instant sourceTimestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    String jsonString = objectMapper.writeValueAsString(sourceTimestamp);
+    Instant targetTimestamp = oldObjectMapper.readValue(jsonString, Instant.class);
+    assertEquals(sourceTimestamp, targetTimestamp);
+  }
+
+  @Test
+  public void testConsistentZonedDateTimeMillisecondsWriting() throws Exception {
+    String timeWithMilliseconds = objectMapper.writeValueAsString(ZonedDateTime.parse("2012-06-30T12:30:40.123Z"));
+    String timeWithoutMilliseconds = objectMapper.writeValueAsString(ZonedDateTime.parse("2012-06-30T12:30:40Z"));
+    assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
+    assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
+  }
+
+  @Test
+  public void testConsistentInstantMillisecondsWriting() throws Exception {
+    String timeWithMicroseconds = objectMapper.writeValueAsString(Instant.parse("2012-06-30T12:30:40.123456Z"));
+    String timeWithMilliseconds = objectMapper.writeValueAsString(Instant.parse("2012-06-30T12:30:40.123Z"));
+    String timeWithoutMilliseconds = objectMapper.writeValueAsString(Instant.parse("2012-06-30T12:30:40Z"));
+
+    assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMicroseconds);
+    assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
+    assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
+  }
+
+}


### PR DESCRIPTION
## Context

Port JavaTimeModuleFactory from old common lib so that the lib can be removed in the future.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
