### PR TITLE
Migrate JsonConverter helper from commons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 build/
 out/
 
+# Idea IDE files
+*.iml
+*.ipr
+*.iws
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2023-08-16
+
+### Added
+
+* Ported `JsonConverter` interface and `DefaultJsonConverter` implementation from old common lib.
+
 ## [1.10.3] - 2023-08-08
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -21,7 +21,8 @@ ext {
             springBootStarter     : "org.springframework.boot:spring-boot-starter",
             springTx              : "org.springframework:spring-tx",
             jacksonDatabind       : "com.fasterxml.jackson.core:jackson-databind",
-            jacksonJsr310         : "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+            jacksonJsr310         : "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+            jacksonJdk8           : "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
 
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.10.3
+version=1.11.0

--- a/tw-base-utils/build.gradle
+++ b/tw-base-utils/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation libraries.slf4jApi
     implementation libraries.jacksonDatabind
     implementation libraries.jacksonJsr310
+    implementation libraries.jacksonJdk8
 
     testImplementation libraries.awaitility
     testImplementation libraries.guava

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
@@ -1,0 +1,57 @@
+package com.transferwise.common.baseutils.jackson;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.transferwise.common.baseutils.ExceptionUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+final class DefaultJsonConverter implements JsonConverter {
+
+  private final ObjectMapper objectMapper;
+
+  public DefaultJsonConverter(ObjectMapper injectedObjectMapper) {
+    this.objectMapper = injectedObjectMapper;
+    objectMapper.registerModule(JavaTimeModuleFactory.consistentMillisecondsTimeModule());
+    objectMapper.registerModule(new Jdk8Module());
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T toObject(String json, Class<T> clazz) {
+    return ExceptionUtils.doUnchecked(() -> objectMapper.readerFor(clazz).readValue(json));
+  }
+
+  @Override
+  public <T> T toObject(byte[] json, Class<T> clazz) {
+    return ExceptionUtils.doUnchecked(() -> objectMapper.readValue(json, clazz));
+  }
+
+  @Override
+  public String fromObject(Object o) {
+    return ExceptionUtils.doUnchecked(() -> objectMapper.writer().writeValueAsString(o));
+  }
+
+  @Override
+  public byte[] fromObjectToBytes(Object o) {
+    return ExceptionUtils.doUnchecked(() -> objectMapper.writeValueAsBytes(o));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> List<T> toList(String json, TypeReference<List<T>> typeRef) {
+    return ExceptionUtils.doUnchecked(() -> objectMapper.readValue(json, typeRef));
+  }
+
+  @Override
+  public <T> List<T> toList(byte[] json, TypeReference<List<T>> typeRef) {
+    return ExceptionUtils.doUnchecked(() -> objectMapper.readValue(json, typeRef));
+  }
+}

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
@@ -6,9 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.transferwise.common.baseutils.ExceptionUtils;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
+import org.springframework.stereotype.Component;
 
 @Component
 final class DefaultJsonConverter implements JsonConverter {

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/JsonConverter.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/JsonConverter.java
@@ -1,7 +1,6 @@
 package com.transferwise.common.baseutils.jackson;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-
 import java.util.List;
 
 public interface JsonConverter {

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/JsonConverter.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/JsonConverter.java
@@ -1,0 +1,20 @@
+package com.transferwise.common.baseutils.jackson;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.List;
+
+public interface JsonConverter {
+
+  <T> T toObject(String json, Class<T> clazz);
+
+  <T> T toObject(byte[] json, Class<T> clazz);
+
+  String fromObject(Object o);
+
+  byte[] fromObjectToBytes(Object o);
+
+  <T> List<T> toList(String json, TypeReference<List<T>> typeRef);
+
+  <T> List<T> toList(byte[] json, TypeReference<List<T>> typeRef);
+}

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/jackson/JsonConverterTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/jackson/JsonConverterTest.java
@@ -1,137 +1,136 @@
 package com.transferwise.common.baseutils.jackson;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class JsonConverterTest {
-    private JsonConverter jsonConverter;
-    private Integer[] array = {1, 2};
+  private JsonConverter jsonConverter;
+  private Integer[] array = {1, 2};
 
-    @BeforeEach
-    public void setUp() {
-        jsonConverter = new DefaultJsonConverter(new ObjectMapper());
-    }
+  @BeforeEach
+  public void setUp() {
+    jsonConverter = new DefaultJsonConverter(new ObjectMapper());
+  }
 
-    @Test
-    public void testFromJsonMapping() {
-        Species dragon = new Species("dragon", 7);
-        String jsonString = jsonConverter.fromObject(dragon);
-        assertEquals(jsonString, "{\"name\":\"dragon\",\"headCount\":7}");
-    }
+  @Test
+  public void testFromJsonMapping() {
+    Species dragon = new Species("dragon", 7);
+    String jsonString = jsonConverter.fromObject(dragon);
+    assertEquals(jsonString, "{\"name\":\"dragon\",\"headCount\":7}");
+  }
 
-    @Test
-    public void testFromObjectToBytesMapping() {
-        Species dragon = new Species("dragon", 7);
-        byte[] json = jsonConverter.fromObjectToBytes(dragon);
-        assertEquals("{\"name\":\"dragon\",\"headCount\":7}", new String(json, StandardCharsets.UTF_8));
-    }
+  @Test
+  public void testFromObjectToBytesMapping() {
+    Species dragon = new Species("dragon", 7);
+    byte[] json = jsonConverter.fromObjectToBytes(dragon);
+    assertEquals("{\"name\":\"dragon\",\"headCount\":7}", new String(json, StandardCharsets.UTF_8));
+  }
 
-    @Test
-    public void testToObjectMapping() {
-        String jsonString = "{\"name\": \"human\", \"headCount\": 1}";
-        Species human = jsonConverter.toObject(jsonString, Species.class);
-        assertEquals(human.getName(), "human");
-        assertEquals(human.getHeadCount(), (Integer) 1);
-    }
+  @Test
+  public void testToObjectMapping() {
+    String jsonString = "{\"name\": \"human\", \"headCount\": 1}";
+    Species human = jsonConverter.toObject(jsonString, Species.class);
+    assertEquals(human.getName(), "human");
+    assertEquals(human.getHeadCount(), (Integer) 1);
+  }
 
-    @Test
-    public void testToObjectFromBytesMapping() {
-        byte[] json = "{\"name\": \"human\", \"headCount\": 1}".getBytes(StandardCharsets.UTF_8);
-        Species human = jsonConverter.toObject(json, Species.class);
-        assertEquals("human", human.getName());
-        assertEquals((Integer) 1, human.getHeadCount());
-    }
+  @Test
+  public void testToObjectFromBytesMapping() {
+    byte[] json = "{\"name\": \"human\", \"headCount\": 1}".getBytes(StandardCharsets.UTF_8);
+    Species human = jsonConverter.toObject(json, Species.class);
+    assertEquals("human", human.getName());
+    assertEquals((Integer) 1, human.getHeadCount());
+  }
 
-    @Test
-    public void testToListMapping() {
-        String jsonString = "[1, 2]";
-        List<Integer> list = jsonConverter.toList(jsonString, new TypeReference<List<Integer>>() {
-        });
-        assertArrayEquals(list.toArray(), array);
-    }
+  @Test
+  public void testToListMapping() {
+    String jsonString = "[1, 2]";
+    List<Integer> list = jsonConverter.toList(jsonString, new TypeReference<List<Integer>>() {
+    });
+    assertArrayEquals(list.toArray(), array);
+  }
 
-    @Test
-    public void testToListFromBytesMapping() {
-        byte[] json = "[1, 2]".getBytes(StandardCharsets.UTF_8);
-        List<Integer> list = jsonConverter.toList(json, new TypeReference<List<Integer>>() {
-        });
-        assertArrayEquals(array, list.toArray());
-    }
+  @Test
+  public void testToListFromBytesMapping() {
+    byte[] json = "[1, 2]".getBytes(StandardCharsets.UTF_8);
+    List<Integer> list = jsonConverter.toList(json, new TypeReference<List<Integer>>() {
+    });
+    assertArrayEquals(array, list.toArray());
+  }
 
-    @Test
-    public void testTimestampBackwardCompatibleReading() {
-        JsonConverter oldJsonConverter = getOldJsonConverter();
-        Instant sourceTimestamp = Instant.now();
-        String jsonString = oldJsonConverter.fromObject(sourceTimestamp);
-        Instant targetTimestamp = jsonConverter.toObject(jsonString, Instant.class);
-        assertEquals(sourceTimestamp, targetTimestamp);
-    }
+  @Test
+  public void testTimestampBackwardCompatibleReading() {
+    JsonConverter oldJsonConverter = getOldJsonConverter();
+    Instant sourceTimestamp = Instant.now();
+    String jsonString = oldJsonConverter.fromObject(sourceTimestamp);
+    Instant targetTimestamp = jsonConverter.toObject(jsonString, Instant.class);
+    assertEquals(sourceTimestamp, targetTimestamp);
+  }
 
-    @Test
-    public void testTimestampBackwardCompatibleWriting() {
-        JsonConverter oldJsonConverter = getOldJsonConverter();
-        // Depending on java version Instant.now may produce micro or nano seconds, but that's not the point of the test, therefore truncating
-        Instant sourceTimestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        String jsonString = jsonConverter.fromObject(sourceTimestamp);
-        Instant targetTimestamp = oldJsonConverter.toObject(jsonString, Instant.class);
-        assertEquals(sourceTimestamp, targetTimestamp);
-    }
+  @Test
+  public void testTimestampBackwardCompatibleWriting() {
+    JsonConverter oldJsonConverter = getOldJsonConverter();
+    // Depending on java version Instant.now may produce micro or nano seconds, but that's not the point of the test, therefore truncating
+    Instant sourceTimestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    String jsonString = jsonConverter.fromObject(sourceTimestamp);
+    Instant targetTimestamp = oldJsonConverter.toObject(jsonString, Instant.class);
+    assertEquals(sourceTimestamp, targetTimestamp);
+  }
 
-    @Test
-    public void testConsistentZonedDateTimeMillisecondsWriting() {
-        String timeWithMilliseconds = jsonConverter.fromObject(ZonedDateTime.parse("2012-06-30T12:30:40.123Z"));
-        String timeWithoutMilliseconds = jsonConverter.fromObject(ZonedDateTime.parse("2012-06-30T12:30:40Z"));
-        assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
-        assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
-    }
+  @Test
+  public void testConsistentZonedDateTimeMillisecondsWriting() {
+    String timeWithMilliseconds = jsonConverter.fromObject(ZonedDateTime.parse("2012-06-30T12:30:40.123Z"));
+    String timeWithoutMilliseconds = jsonConverter.fromObject(ZonedDateTime.parse("2012-06-30T12:30:40Z"));
+    assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
+    assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
+  }
 
-    @Test
-    public void testConsistentInstantMillisecondsWriting() {
-        String timeWithMicroseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40.123456Z"));
-        String timeWithMilliseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40.123Z"));
-        String timeWithoutMilliseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40Z"));
+  @Test
+  public void testConsistentInstantMillisecondsWriting() {
+    String timeWithMicroseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40.123456Z"));
+    String timeWithMilliseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40.123Z"));
+    String timeWithoutMilliseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40Z"));
 
-        assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMicroseconds);
-        assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
-        assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
-    }
+    assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMicroseconds);
+    assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
+    assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
+  }
 
-    private ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.registerModule(new Jdk8Module());
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.registerModule(new Jdk8Module());
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-        return objectMapper;
-    }
+    return objectMapper;
+  }
 
-    private JsonConverter getOldJsonConverter() {
-        return new DefaultJsonConverter(objectMapper());
-    }
+  private JsonConverter getOldJsonConverter() {
+    return new DefaultJsonConverter(objectMapper());
+  }
 
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    private static class Species {
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  private static class Species {
 
-        private String name;
-        private Integer headCount;
-    }
+    private String name;
+    private Integer headCount;
+  }
 }

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/jackson/JsonConverterTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/jackson/JsonConverterTest.java
@@ -1,0 +1,137 @@
+package com.transferwise.common.baseutils.jackson;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonConverterTest {
+    private JsonConverter jsonConverter;
+    private Integer[] array = {1, 2};
+
+    @BeforeEach
+    public void setUp() {
+        jsonConverter = new DefaultJsonConverter(new ObjectMapper());
+    }
+
+    @Test
+    public void testFromJsonMapping() {
+        Species dragon = new Species("dragon", 7);
+        String jsonString = jsonConverter.fromObject(dragon);
+        assertEquals(jsonString, "{\"name\":\"dragon\",\"headCount\":7}");
+    }
+
+    @Test
+    public void testFromObjectToBytesMapping() {
+        Species dragon = new Species("dragon", 7);
+        byte[] json = jsonConverter.fromObjectToBytes(dragon);
+        assertEquals("{\"name\":\"dragon\",\"headCount\":7}", new String(json, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testToObjectMapping() {
+        String jsonString = "{\"name\": \"human\", \"headCount\": 1}";
+        Species human = jsonConverter.toObject(jsonString, Species.class);
+        assertEquals(human.getName(), "human");
+        assertEquals(human.getHeadCount(), (Integer) 1);
+    }
+
+    @Test
+    public void testToObjectFromBytesMapping() {
+        byte[] json = "{\"name\": \"human\", \"headCount\": 1}".getBytes(StandardCharsets.UTF_8);
+        Species human = jsonConverter.toObject(json, Species.class);
+        assertEquals("human", human.getName());
+        assertEquals((Integer) 1, human.getHeadCount());
+    }
+
+    @Test
+    public void testToListMapping() {
+        String jsonString = "[1, 2]";
+        List<Integer> list = jsonConverter.toList(jsonString, new TypeReference<List<Integer>>() {
+        });
+        assertArrayEquals(list.toArray(), array);
+    }
+
+    @Test
+    public void testToListFromBytesMapping() {
+        byte[] json = "[1, 2]".getBytes(StandardCharsets.UTF_8);
+        List<Integer> list = jsonConverter.toList(json, new TypeReference<List<Integer>>() {
+        });
+        assertArrayEquals(array, list.toArray());
+    }
+
+    @Test
+    public void testTimestampBackwardCompatibleReading() {
+        JsonConverter oldJsonConverter = getOldJsonConverter();
+        Instant sourceTimestamp = Instant.now();
+        String jsonString = oldJsonConverter.fromObject(sourceTimestamp);
+        Instant targetTimestamp = jsonConverter.toObject(jsonString, Instant.class);
+        assertEquals(sourceTimestamp, targetTimestamp);
+    }
+
+    @Test
+    public void testTimestampBackwardCompatibleWriting() {
+        JsonConverter oldJsonConverter = getOldJsonConverter();
+        // Depending on java version Instant.now may produce micro or nano seconds, but that's not the point of the test, therefore truncating
+        Instant sourceTimestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        String jsonString = jsonConverter.fromObject(sourceTimestamp);
+        Instant targetTimestamp = oldJsonConverter.toObject(jsonString, Instant.class);
+        assertEquals(sourceTimestamp, targetTimestamp);
+    }
+
+    @Test
+    public void testConsistentZonedDateTimeMillisecondsWriting() {
+        String timeWithMilliseconds = jsonConverter.fromObject(ZonedDateTime.parse("2012-06-30T12:30:40.123Z"));
+        String timeWithoutMilliseconds = jsonConverter.fromObject(ZonedDateTime.parse("2012-06-30T12:30:40Z"));
+        assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
+        assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
+    }
+
+    @Test
+    public void testConsistentInstantMillisecondsWriting() {
+        String timeWithMicroseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40.123456Z"));
+        String timeWithMilliseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40.123Z"));
+        String timeWithoutMilliseconds = jsonConverter.fromObject(Instant.parse("2012-06-30T12:30:40Z"));
+
+        assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMicroseconds);
+        assertEquals("\"2012-06-30T12:30:40.000Z\"", timeWithoutMilliseconds);
+        assertEquals("\"2012-06-30T12:30:40.123Z\"", timeWithMilliseconds);
+    }
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return objectMapper;
+    }
+
+    private JsonConverter getOldJsonConverter() {
+        return new DefaultJsonConverter(objectMapper());
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class Species {
+
+        private String name;
+        private Integer headCount;
+    }
+}


### PR DESCRIPTION
## Context

Migrating the JsonConverter interface with a Default implementation, along with the tests, from the older & deprecated tw.commons library

https://github.com/transferwise/common/blob/940e526884c21055237a9e65a28d0498fc1a7d01/src/main/java/com/transferwise/common/mapper/DefaultJsonConverter.java#L15

It's used in a lot of places, so having this here helps remove copy & pasting of the code and removes dependency on tw.commons

https://github.com/search?q=org%3Atransferwise%20DefaultJsonConverter&type=code

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
