### PR TITLE
Remove @Component from DefaultJsonConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2023-08-17
+
+### Fixed
+
+* Fixes issue of DefaultJsonConverter being incorrectly set as a @Component.
+
 ## [1.11.0] - 2023-08-16
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.11.0
+version=1.11.1

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 
-final public class DefaultJsonConverter implements JsonConverter {
+public final class DefaultJsonConverter implements JsonConverter {
 
   private final ObjectMapper objectMapper;
 

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/jackson/DefaultJsonConverter.java
@@ -9,8 +9,8 @@ import com.transferwise.common.baseutils.ExceptionUtils;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-@Component
-final class DefaultJsonConverter implements JsonConverter {
+
+final public class DefaultJsonConverter implements JsonConverter {
 
   private final ObjectMapper objectMapper;
 


### PR DESCRIPTION
## Context

I incorrectly assumed that, because the annotations were on the classpath, that this would propagate the bean to the consumer. It doesn't, so for now just setting it as a public class and removing the annotation.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
