### PR TITLE
Added UuidUtils add method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2023-10-29
+
+### Added
+
+* UuidUtils.add method.
+
 ## [1.12.0] - 2023-10-03
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.12.0
+version=1.12.1

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -92,8 +92,8 @@ public class UuidUtils {
     return bytes;
   }
 
-  public static UUID add(UUID uuid, long constant){
-    if (uuid == null){
+  public static UUID add(UUID uuid, long constant) {
+    if (uuid == null) {
       throw new NullPointerException("Can not add anything to null.");
     }
 

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -92,6 +92,15 @@ public class UuidUtils {
     return bytes;
   }
 
+  public static UUID add(UUID uuid, long constant){
+    if (uuid == null){
+      throw new NullPointerException("Can not add anything to null.");
+    }
+
+    // Can overflow, but this is fine.
+    return new UUID(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits() + constant);
+  }
+
   protected static long applyVersionBits(final long msb, int versionBits) {
     return (msb & 0xffffffffffff0fffL) | versionBits;
   }


### PR DESCRIPTION
## Context

Added UuidUtils add method to add a constant to an UUID.

This would easily allow services to branch out UUIDs.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
