### PR TITLE
Fixes stopping of wrong scheduled tasks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,10 +20,9 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 3.1.2
-          - 3.0.7
-          - 2.7.13
-          - 2.6.15
+          - 3.1.6
+          - 3.0.13
+          - 2.7.18
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.2] - 2024-01-05
+
+### Fixed
+
+* Stopping a scheduled task does not stop other tasks with the same execution time.
+
+## [1.12.1] - 2023-10-29
+
+### Added
+
+* UuidUtils.add method.
+
 ## [1.12.1] - 2023-10-29
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,9 +1,10 @@
 ext {
-    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: "2.6.15"}"
+    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: "2.7.18"}"
 
     libraries = [
             // version defined
             awaitility            : "org.awaitility:awaitility:4.2.0",
+            guava                 : 'com.google.guava:guava:33.0.0-jre',
             jakartaValidationApi  : 'jakarta.validation:jakarta.validation-api:3.0.2',
             javaxValidationApi    : "javax.validation:validation-api:2.0.1.Final",
             spockCore             : "org.spockframework:spock-core:2.3-groovy-4.0",
@@ -11,7 +12,6 @@ ext {
 
             // versions managed by spring-boot-dependencies platform
             commonsLang3          : "org.apache.commons:commons-lang3",
-            guava                 : 'com.google.guava:guava:31.1-jre',
             junitJupiter          : "org.junit.jupiter:junit-jupiter",
             logbackClassic        : "ch.qos.logback:logback-classic",
             lombok                : "org.projectlombok:lombok",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.12.1
+version=1.12.2

--- a/tw-base-utils/build.gradle
+++ b/tw-base-utils/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation libraries.jacksonDatabind
     implementation libraries.jacksonJsr310
     implementation libraries.jacksonJdk8
+    implementation libraries.guava
 
     testImplementation libraries.awaitility
     testImplementation libraries.guava

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/concurrency/DefaultExecutorServicesProvider.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/concurrency/DefaultExecutorServicesProvider.java
@@ -22,7 +22,7 @@ public class DefaultExecutorServicesProvider implements IExecutorServicesProvide
     try {
       if (!initialized) {
         executorService = Executors.newCachedThreadPool(new CountingThreadFactory("tw-base"));
-        scheduledTaskExecutor = new SimpleScheduledTaskExecutor(null, executorService);
+        scheduledTaskExecutor = new SimpleScheduledTaskExecutor("gste", executorService);
         scheduledTaskExecutor.start();
         initialized = true;
       }


### PR DESCRIPTION
## Context

Currently when a scheduled task was stopped by its handle, it caused the stoppage of all tasks which had the same delay left.

Fixes stopping of wrong scheduled tasks.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
