### PR TITLE
Add support for Spring Boot 3.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
+          - 3.2.2
           - 3.1.6
           - 3.0.13
           - 2.7.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.4] - 2024-02-22
+
+### Changed
+
+* Added support for Spring Boot 3.2.
+
 ## [1.12.3] - 2024-01-11
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.12.3
+version=1.12.4


### PR DESCRIPTION
## Context

Add support for Spring Boot 3.2. All necessary changes are covered in the changelog file.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
