### PR TITLE
[APPENG-849] Update matrix tests to run with SB3.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,8 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
+          - 3.3.1
           - 3.2.2
-          - 3.1.6
-          - 3.0.13
           - 2.7.18
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,6 @@ jobs:
         spring_boot_version:
           - 3.3.1
           - 3.2.2
-          - 2.7.18
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.5] - 2024-07-16
+
+### Changed
+
+* Added support for Spring Boot 3.3.
+
+
 ## [1.12.4] - 2024-02-22
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.12.4
+version=1.12.5


### PR DESCRIPTION
## Context

Wise is now supporting Spring Boot 3.3 so matrix tests need to be updated to run with the new version.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-849](https://transferwise.atlassian.net/browse/APPENG-849)

### Update platform libraries matrix tests to run with boot 3.3

>Tracking the specific libraries here:
>
>[https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit?gid=618138693#gid=618138693a|https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit?gid=618138693#gid=618138693a|smart-link] 


[APPENG-849]: https://transferwise.atlassian.net/browse/APPENG-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ