### PR TITLE
SECENG-3602: add UUIDv7 methods, deprecate `prefixComb` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2025-07-10
+
+### Changed
+- Added support for generating [UUIDv7](https://uuid7.com/)s.
+- Deprecated prefix combined UUIDv4s in favour of UUIDv7.
+
 ## [1.13.4] - 2025-06-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.14.0] - 2025-07-10
 
 ### Changed
-- Added support for generating [UUIDv7](https://uuid7.com/)s.
-- Deprecated prefix combined UUIDv4s in favour of UUIDv7.
+- Added support for generating [UUIDv7](https://uuid7.com/)s (`generateTimePrefixedUuid`).
+- Added support for generating UUIDv8s. This implementation (`generateDeterministicTimePrefixedUuid`) is a combination of UUIDv7's time-prefixing and UUIDv3's seeding.
+- Deprecated prefix combined UUIDv4s in favour of UUIDv7s or UUIDv8s (as appropriate).
 
 ## [1.13.4] - 2025-06-17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.13.4
+version=1.14.0

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -28,12 +28,56 @@ public class UuidUtils {
   }
 
   /**
+   * Timestamp-prefixed UUID for where UUIDs should be time-sortable, see <a href="https://uuid7.com/">uuid7.com</a> for details.
+   *
+   * <p>This UUID is not suitable for things like session and authentication tokens.
+   */
+  public static UUID generateUuidv7() {
+    long timestamp = ClockHolder.getClock().millis();
+    return generateUuidv7(timestamp);
+  }
+
+  /**
+   * Timestamp-prefixed UUID for where UUIDs should be time-sortable, see <a href="https://uuid7.com/">uuid7.com</a> for details.
+   *
+   * <p>This UUID is not suitable for things like session and authentication tokens.
+   *
+   * @param timestamp provided timestamp milliseconds from epoch.
+   */
+  public static UUID generateUuidv7(long timestamp) {
+    // use built-in implementation once https://bugs.openjdk.org/browse/JDK-8334015 is done and released
+    byte[] bytes = new byte[16];
+    numberGenerator.nextBytes(bytes);
+
+    // Embed the timestamp into the first 6 bytes
+    bytes[0] = (byte)(timestamp >>> 40);
+    bytes[1] = (byte)(timestamp >>> 32);
+    bytes[2] = (byte)(timestamp >>> 24);
+    bytes[3] = (byte)(timestamp >>> 16);
+    bytes[4] = (byte)(timestamp >>> 8);
+    bytes[5] = (byte)(timestamp);
+
+    // Set version to 7
+    bytes[6] &= 0x0f;
+    bytes[6] |= 0x70;
+
+    // Set variant to IETF
+    bytes[8] &= 0x3f;
+    bytes[8] |= (byte) 0x80;
+
+    return toUuid(bytes);
+  }
+
+  /**
    * Random UUID with 38 bit prefix based on current milliseconds from epoch.
    *
    * <p>Giving about 3181 days roll-over.
    *
    * <p>This UUID is not suitable for things like session and authentication tokens.
+   *
+   * @deprecated in a favour of {@link #generateUuidv7()}.
    */
+  @Deprecated(forRemoval = false)
   public static UUID generatePrefixCombUuid() {
     return generatePrefixCombUuid(38);
   }
@@ -44,7 +88,10 @@ public class UuidUtils {
    * <p>Giving about 3181 days roll-over.
    *
    * <p>This UUID is not suitable for things like session and authentication tokens.
+   *
+   * @deprecated in a favour of {@link #generateUuidv7()} and related methods. Note that we do not have an exact equivalent to this (yet).
    */
+  @Deprecated(forRemoval = false)
   public static UUID generatePrefixCombUuid(long timestamp, UUID uuid) {
     return generatePrefixCombUuid(timestamp, uuid, 38);
   }
@@ -61,7 +108,10 @@ public class UuidUtils {
    * @param timestamp provided timestamp milliseconds from epoch.
    * @param uuid provided uuid.
    * @param timePrefixLengthBits technically we left-shift the current time-millis by that amount.
+   *
+   * @deprecated in a favour of {@link #generateUuidv7()} and related methods. Note that we do not have an exact equivalent to this (yet).
    */
+  @Deprecated(forRemoval = false)
   public static UUID generatePrefixCombUuid(long timestamp, UUID uuid, int timePrefixLengthBits) {
     if (timePrefixLengthBits < 1 || timePrefixLengthBits > 63) {
       throw new IllegalArgumentException("Prefix length " + timePrefixLengthBits + " has to be between 1 and 63, inclusively.");
@@ -82,7 +132,10 @@ public class UuidUtils {
    * <p>This UUID is not suitable for things like session and authentication tokens.
    *
    * @param timePrefixLengthBits technically we left-shift the current time-millis by that amount.
+   *
+   * @deprecated in a favour of {@link #generateUuidv7()}. Note that UUIDv7s have a fixed 48-bit timestamp prefix.
    */
+  @Deprecated(forRemoval = false)
   public static UUID generatePrefixCombUuid(int timePrefixLengthBits) {
     if (timePrefixLengthBits < 1 || timePrefixLengthBits > 63) {
       throw new IllegalArgumentException("Prefix length " + timePrefixLengthBits + " has to be between 1 and 63, inclusively.");

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -123,7 +123,8 @@ public class UuidUtils {
    * @param uuid provided uuid.
    * @param timePrefixLengthBits technically we left-shift the current time-millis by that amount.
    *
-   * @deprecated in a favour of {@link #generateTimePrefixedUuid()} and related methods. Note that we do not have an exact equivalent to this (yet).
+   * @deprecated in a favour of {@link #generateDeterministicTimePrefixedUuid(long timestamp, byte[] data)}.
+   *     Note that the replacement method has a fixed 48-bit timestamp prefix.
    */
   @Deprecated(forRemoval = false)
   public static UUID generatePrefixCombUuid(long timestamp, UUID uuid, int timePrefixLengthBits) {
@@ -202,7 +203,7 @@ public class UuidUtils {
     return new UUID(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits() + constant);
   }
 
-  protected static void applyV7StyleTimestampBits(long timestamp, byte[] bytes) {
+  private static void applyV7StyleTimestampBits(long timestamp, byte[] bytes) {
     bytes[0] = (byte)(timestamp >>> 40);
     bytes[1] = (byte)(timestamp >>> 32);
     bytes[2] = (byte)(timestamp >>> 24);
@@ -211,17 +212,17 @@ public class UuidUtils {
     bytes[5] = (byte)(timestamp);
   }
 
-  protected static long applyVersionBits(final long msb, int versionBits) {
+  private static long applyVersionBits(final long msb, int versionBits) {
     return (msb & 0xffffffffffff0fffL) | versionBits;
   }
 
-  protected static void applyVersionBits(int version, byte[] bytes) {
+  private static void applyVersionBits(int version, byte[] bytes) {
     // Set version bits
     bytes[6] &= 0x0f;
     bytes[6] |= (byte) (version << 4);
   }
 
-  protected static void applyIetfVariantBits(byte[] bytes) {
+  private static void applyIetfVariantBits(byte[] bytes) {
     // Set variant to IETF
     bytes[8] &= 0x3f;
     bytes[8] |= (byte) 0x80;

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/UuidUtils.java
@@ -31,6 +31,8 @@ public class UuidUtils {
    * Timestamp-prefixed UUID for where UUIDs should be time-sortable, see <a href="https://uuid7.com/">uuid7.com</a> for details.
    *
    * <p>This UUID is not suitable for things like session and authentication tokens.
+   *
+   * <p>This method is likely to be deprecated once <a href="https://bugs.openjdk.org/browse/JDK-8334015">JDK-8334015</a> has been released, in favour of the built-in UUIDv7 implementation.
    */
   public static UUID generateTimePrefixedUuid() {
     long timestamp = ClockHolder.getClock().millis();
@@ -41,6 +43,8 @@ public class UuidUtils {
    * Timestamp-prefixed UUID for where UUIDs should be time-sortable, see <a href="https://uuid7.com/">uuid7.com</a> for details.
    *
    * <p>This UUID is not suitable for things like session and authentication tokens.
+   *
+   * <p>This method is likely to be deprecated once <a href="https://bugs.openjdk.org/browse/JDK-8334015">JDK-8334015</a> has been released, in favour of the built-in UUIDv7 implementation.
    *
    * @param timestamp provided timestamp milliseconds from epoch.
    */

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/UuidUtilsTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/UuidUtilsTest.java
@@ -34,15 +34,42 @@ class UuidUtilsTest extends BaseTest {
 
     long previousTime = -1;
     for (int i = 0; i < n; i++) {
+      System.out.println("Testing " + uuids[i]);
+      assertEquals(4, uuids[i].version());
       long time = uuids[i].getMostSignificantBits() >>> (64 - 38);
 
       if (previousTime != -1) {
         assertTrue(previousTime < time);
       }
       previousTime = time;
+    }
 
-      System.out.println(uuids[i]);
-      assertEquals(4, uuids[i].version());
+    assertTrue(Ordering.natural().isOrdered(Arrays.asList(uuids)));
+    assertEquals(n, Set.of(uuids).size());
+  }
+
+  @Test
+  void uuidv7IsGrowingOverTime() {
+    TestClock clock = TestClock.createAndRegister();
+
+    int n = 100;
+
+    UUID[] uuids = new UUID[n];
+    for (int i = 0; i < n; i++) {
+      uuids[i] = UuidUtils.generateUuidv7();
+      clock.tick(Duration.ofMillis(2));
+    }
+
+    long previousTime = -1;
+    for (int i = 0; i < n; i++) {
+      System.out.println("Testing " + uuids[i]);
+      assertEquals(7, uuids[i].version());
+      long time = uuids[i].getMostSignificantBits() >>> (64 - 48);
+
+      if (previousTime != -1) {
+        assertTrue(previousTime < time);
+      }
+      previousTime = time;
     }
 
     assertTrue(Ordering.natural().isOrdered(Arrays.asList(uuids)));

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/UuidUtilsTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/UuidUtilsTest.java
@@ -144,7 +144,36 @@ class UuidUtilsTest extends BaseTest {
   }
 
   @Test
-  void addingConstantDoesNotChangeOrdering() {
+  void addingConstantDoesNotChangeOrderingOfPrefixCombUuid() {
+    TestClock clock = TestClock.createAndRegister();
+
+    int n = 100;
+
+    UUID[] uuids = new UUID[n];
+    for (int i = 0; i < n; i++) {
+      uuids[i] = UuidUtils.add(UuidUtils.generatePrefixCombUuid(), ThreadLocalRandom.current().nextInt());
+      clock.tick(Duration.ofMillis(2));
+    }
+
+    long previousTime = -1;
+    for (int i = 0; i < n; i++) {
+      long time = uuids[i].getMostSignificantBits() >>> (64 - 48);
+
+      if (previousTime != -1) {
+        assertTrue(previousTime < time);
+      }
+      previousTime = time;
+
+      System.out.println(uuids[i]);
+      assertEquals(4, uuids[i].version());
+    }
+
+    assertTrue(Ordering.natural().isOrdered(Arrays.asList(uuids)));
+    assertEquals(n, Set.of(uuids).size());
+  }
+
+  @Test
+  void addingConstantDoesNotChangeOrderingOfTimePrefixedUuid() {
     TestClock clock = TestClock.createAndRegister();
 
     int n = 100;

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/UuidUtilsTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/UuidUtilsTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Ordering;
 import com.transferwise.common.baseutils.clock.TestClock;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -49,21 +50,26 @@ class UuidUtilsTest extends BaseTest {
   }
 
   @Test
-  void uuidv7IsGrowingOverTime() {
+  void timePrefixedUuidIsVersion7() {
+    UUID uuid = UuidUtils.generateTimePrefixedUuid();
+    assertEquals(7, uuid.version());
+  }
+
+  @Test
+  void timePrefixedUuidIsGrowingOverTime() {
     TestClock clock = TestClock.createAndRegister();
 
     int n = 100;
 
     UUID[] uuids = new UUID[n];
     for (int i = 0; i < n; i++) {
-      uuids[i] = UuidUtils.generateUuidv7();
+      uuids[i] = UuidUtils.generateTimePrefixedUuid();
       clock.tick(Duration.ofMillis(2));
     }
 
     long previousTime = -1;
     for (int i = 0; i < n; i++) {
       System.out.println("Testing " + uuids[i]);
-      assertEquals(7, uuids[i].version());
       long time = uuids[i].getMostSignificantBits() >>> (64 - 48);
 
       if (previousTime != -1) {
@@ -77,8 +83,59 @@ class UuidUtilsTest extends BaseTest {
   }
 
   @Test
+  void deterministicTimePrefixedUuidIsVersion8() {
+    UUID uuid = UuidUtils.generateDeterministicTimePrefixedUuid(new byte[0]);
+    System.out.println(uuid);
+    assertEquals(8, uuid.version());
+  }
+
+  @Test
+  void deterministicTimePrefixedUuidIsGrowingOverTime() {
+    TestClock clock = TestClock.createAndRegister();
+
+    int n = 100;
+
+    UUID[] uuids = new UUID[n];
+    for (int i = 0; i < n; i++) {
+      uuids[i] = UuidUtils.generateDeterministicTimePrefixedUuid(new byte[0]);
+      clock.tick(Duration.ofMillis(2));
+    }
+
+    long previousTime = -1;
+    for (int i = 0; i < n; i++) {
+      System.out.println("Testing " + uuids[i]);
+      long time = uuids[i].getMostSignificantBits() >>> (64 - 48);
+
+      if (previousTime != -1) {
+        assertTrue(previousTime < time);
+      }
+      previousTime = time;
+    }
+
+    assertTrue(Ordering.natural().isOrdered(Arrays.asList(uuids)));
+    assertEquals(n, Set.of(uuids).size());
+  }
+
+  @Test
+  void deterministicTimePrefixedUuidIsFullyDeterministic() {
+    long timestamp = System.currentTimeMillis();
+    byte[] seed = "Ben was here".getBytes(StandardCharsets.UTF_8);
+    UUID uuid1 = UuidUtils.generateDeterministicTimePrefixedUuid(timestamp, seed);
+    UUID uuid2 = UuidUtils.generateDeterministicTimePrefixedUuid(timestamp, seed);
+    assertEquals(uuid1, uuid2);
+  }
+
+  @Test
+  void deterministicTimePrefixedUuidChangesWithDifferentData() {
+    long timestamp = System.currentTimeMillis();
+    UUID uuid1 = UuidUtils.generateDeterministicTimePrefixedUuid(timestamp, "Ben was here".getBytes(StandardCharsets.UTF_8));
+    UUID uuid2 = UuidUtils.generateDeterministicTimePrefixedUuid(timestamp, "Ben was not here".getBytes(StandardCharsets.UTF_8));
+    assertNotEquals(uuid1, uuid2);
+  }
+
+  @Test
   void constantCanBeAddedToUuid() {
-    var uuid = UuidUtils.generatePrefixCombUuid();
+    var uuid = UuidUtils.generateTimePrefixedUuid();
     var uuidWithConstant = UuidUtils.add(uuid, 11111);
 
     assertNotEquals(uuidWithConstant, uuid);
@@ -94,13 +151,13 @@ class UuidUtilsTest extends BaseTest {
 
     UUID[] uuids = new UUID[n];
     for (int i = 0; i < n; i++) {
-      uuids[i] = UuidUtils.add(UuidUtils.generatePrefixCombUuid(), ThreadLocalRandom.current().nextInt());
+      uuids[i] = UuidUtils.add(UuidUtils.generateTimePrefixedUuid(), ThreadLocalRandom.current().nextInt());
       clock.tick(Duration.ofMillis(2));
     }
 
     long previousTime = -1;
     for (int i = 0; i < n; i++) {
-      long time = uuids[i].getMostSignificantBits() >>> (64 - 38);
+      long time = uuids[i].getMostSignificantBits() >>> (64 - 48);
 
       if (previousTime != -1) {
         assertTrue(previousTime < time);
@@ -108,7 +165,7 @@ class UuidUtilsTest extends BaseTest {
       previousTime = time;
 
       System.out.println(uuids[i]);
-      assertEquals(4, uuids[i].version());
+      assertEquals(7, uuids[i].version());
     }
 
     assertTrue(Ordering.natural().isOrdered(Arrays.asList(uuids)));


### PR DESCRIPTION
## Context
This PR adds new methods for generating [UUIDv7](https://uuid7.com/)s and deprecates the methods which generated non-standard time prefixed UUIDv4s (`generatePrefixCombUuid(...)`).

I'm assuming that the reasons for wanting a timestamp-prefixed UUID are pretty clear, but if not see [the prefix-combed UUID section of this fantastic article](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/3184789016/Consistent+and+idempotent+processing+in+multi-step+flows#Prefix-combed-UUIDs) by @onukristo. [UUIDv7 was first introduced in RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-7) (May 2024) which post-dates the article, but fundamentally it is very similar to the prefixed UUIDv4 described by Kristo.

Where possible, we should prefer open standards over home-brewed solutions. This is because open standards are more likely to be supported in other dependencies that we may want to use, and they've had more eyes reviewing them for potential bugs or flaws. We should therefore cease using our proprietary time prefixed UUIDs in favour of the standard UUIDv7. The problem with this is that the Java core libraries do not (yet) support UUIDv7 natively. [JDK-8334015](https://bugs.openjdk.org/browse/JDK-8334015) is tracking this and a PR exists, but it will take a while before this functionality arrives in [LTS-1](https://transferwise.atlassian.net/wiki/spaces/PLAT/pages/2211022367/Supported+Java+Versions).

As an interim measure (and to ultimately reduce the number of places where we're using our proprietary UUID format) the code used to generate UUIDv7s has taken heavy inspiration from [the code being offered as part of the OpenJDK PR](https://github.com/openjdk/jdk/blob/be7dea7a5be2716c204a969ec68bf1879a6b7e33/src/java.base/share/classes/java/util/UUID.java#L241). The alternative would be to include a new dependency as part of `tw-base-utils` but the cost of this (the risk of a supply chain attack) seems to exceed the benefit given the specific and limited (~13 LOC) nature of the code.

Neither the old nor new timestamping methods provide any monotonic guarantees. If monotonicity is required then the `public static UUID generateUuidv7(long timestamp)` method should be used with a suitable `timestamp` parameter.

With these changes we can now use the UUID version number to determine the type of UUID. Previously all UUIDs were being generated with the version set to 4, but now only secure (random) UUIDs are version 4, with the new deterministic method returning version 8 and the new timestamp prefixed methods returning version 7.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
