### PR TITLE
Fixing MeterCache mess, so that it does not get corrupted and waste huge amounts of memory.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,8 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 3.4.6
-          - 3.5.0
+          - 3.4.8
+          - 3.5.4
 
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.1] - 2025-07-24
+
+### Fixed
+- Flakiness of equals method in TagsSetArray.
+
 ## [1.14.0] - 2025-07-10
 
 ### Changed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,11 +1,11 @@
 ext {
-    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: "3.2.2"}"
+    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: "3.4.8"}"
 
     libraries = [
             // version defined
-            awaitility            : "org.awaitility:awaitility:4.2.2",
-            commonsIo             : "commons-io:commons-io:2.17.0",
-            guava                 : 'com.google.guava:guava:33.3.1-jre',
+            awaitility            : "org.awaitility:awaitility:4.3.0",
+            commonsIo             : "commons-io:commons-io:2.20.0",
+            guava                 : 'com.google.guava:guava:33.4.0-jre',
             jakartaValidationApi  : 'jakarta.validation:jakarta.validation-api:3.0.2',
             javaxValidationApi    : "javax.validation:validation-api:2.0.1.Final",
             roaringBitmap         : 'org.roaringbitmap:RoaringBitmap:1.3.0',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.14.0
+version=1.14.1

--- a/tw-base-utils/src/main/java/com/transferwise/common/baseutils/meters/cache/TagsSet.java
+++ b/tw-base-utils/src/main/java/com/transferwise/common/baseutils/meters/cache/TagsSet.java
@@ -61,9 +61,10 @@ public abstract class TagsSet {
       return Arrays.equals(this.tags, ((ArrayTagsSet) other).tags);
     }
 
+    // Cloning is necessary to avoid Micrometer sorting our own array, making equals method flaky.
     @Override
     public Tags getMicrometerTags() {
-      return Tags.of(tags);
+      return Tags.of(Arrays.copyOf(tags, tags.length));
     }
   }
 

--- a/tw-base-utils/src/test/java/com/transferwise/common/baseutils/meters/cache/MeterCacheTest.java
+++ b/tw-base-utils/src/test/java/com/transferwise/common/baseutils/meters/cache/MeterCacheTest.java
@@ -59,13 +59,14 @@ class MeterCacheTest {
     final var tag2 = Tag.of("tag2", "tagValue2");
     final var counterName = "my.test.counter";
 
-    var counter0 = meterCache.counter(counterName, TagsSet.of(tag0, tag1));
-    var counter1 = meterCache.counter(counterName, TagsSet.of(tag0, tag1));
+    // Notice the reverse order of tags, so that micrometer will be reordering them.
+    var counter0 = meterCache.counter(counterName, TagsSet.of(tag1, tag0));
+    var counter1 = meterCache.counter(counterName, TagsSet.of(tag1, tag0));
 
     assertSame(counter0, counter1);
     assertEquals(1, meterCache.size());
 
-    var counter2 = meterCache.counter(counterName, TagsSet.of(tag1, tag0));
+    var counter2 = meterCache.counter(counterName, TagsSet.of(tag0, tag1));
     //Even when cache is different, the underlying meterRegistry provides same counter.
     assertSame(counter0, counter2);
     assertEquals(2, meterCache.size());


### PR DESCRIPTION
## Context

Fixing MeterCache mess, so that it does not get corrupted and waste huge amounts of memory.

The Micrometer version in Spring Boot 3.4+ does not clone a given tags array and when it reorders the tag, our equals and hash code methods do not reflect previous state. The map will get corrupted with symptoms of relatively empty map wasting gigabytes of memory.

This pull request includes updates to dependencies, bug fixes, and test improvements to enhance stability and maintainability. The most important changes include upgrading Spring Boot and other libraries, fixing a bug in the `TagsSet` class to address flakiness in the `equals` method, and updating related tests for robustness.

### Dependency Updates:
* Updated Spring Boot versions in `.github/workflows/build.yaml` and `build.libraries.gradle` to `3.4.8` and `3.5.4`. Default version in `build.libraries.gradle` is now `3.4.8`. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L30-R31) [[2]](diffhunk://#diff-ac5e7934d35ccb90c846a04165a3819982fbd7c46a2d9bae94d93f200a2363dbL2-R8)
* Upgraded library dependencies: `awaitility` to `4.3.0`, `commons-io` to `2.20.0`, and `guava` to `33.4.0-jre`.

### Bug Fixes:
* Fixed flakiness in the `TagsSet` class `equals` method by cloning the tags array to prevent external modifications by Micrometer.

### Test Improvements:
* Updated `MeterCacheTest` to account for tag reordering by Micrometer, ensuring test reliability regardless of tag order.

### Versioning:
* Incremented project version from `1.14.0` to `1.14.1` in `gradle.properties` and documented changes in `CHANGELOG.md`. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-R1) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12)

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
